### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
   <% if @items.empty? %>
   <!-- 商品がないときのダミー表示 -->
   <li class='list'>
-    <%= link_to item_path(item) do %>
+    <%= link_to '#' do %>
       <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
       <div class='item-info'>
         <h3 class='item-name'>商品を出品してね！</h3>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
   <% if @items.empty? %>
   <!-- 商品がないときのダミー表示 -->
   <li class='list'>
-    <%= link_to '#' do %>
+    <%= link_to item_path(item) do %>
       <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
       <div class='item-info'>
         <h3 class='item-name'>商品を出品してね！</h3>
@@ -150,11 +150,11 @@
   <!-- 商品がある場合の一覧表示 -->
   <% @items.each do |item| %>
     <li class='list'>
-      <%= link_to '#' do %>
+      <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
-         
+
         </div>
         <div class='item-info'>
           <h3 class='item-name'><%= item.name %></h3>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,12 +22,15 @@
         <%= @item.shipping_fee_status.name %>
       </span>
     </div>
+ 
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%# ログイン中のユーザーが出品者の場合（編集・削除ボタン表示） %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
-
-    <% if user_signed_in? && current_user.id != @item.user_id %>
+    <% elsif user_signed_in? && current_user.id != @item.user_id %>
+      <%# ログイン中の他人（購入ボタン表示） %>
       <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,15 +23,14 @@
       </span>
     </div>
  
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%# ログイン中のユーザーが出品者の場合（編集・削除ボタン表示） %>
+    <% if user_signed_in? %>
+     <% if current_user.id == @item.user_id %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
-
-    <% elsif user_signed_in? && current_user.id != @item.user_id %>
-      <%# ログイン中の他人（購入ボタン表示） %>
+     <% else %>
       <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+     <% end %> 
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,85 +1,80 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
+
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-    </div>
-    <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
-      <span class="item-postage">
-        <%= "配送料負担" %>
-      </span>
+      <% if @item.image.attached? %>
+        <div class="item-image-wrapper">
+          <%= image_tag @item.image, class: "item-box-img" %>
+        </div>
+      <% end %>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= number_with_delimiter(@item.price) %>
+      </span>
+      <span class="item-postage">
+        <%= @item.shipping_fee_status.name %>
+      </span>
+    </div>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
 
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
+
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>
+
     <div class="option">
       <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <%= image_tag "star.png", class: "favorite-star-icon", width: "20", height: "20" %>
         <span>お気に入り 0</span>
       </div>
       <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <%= image_tag "flag.png", class: "report-flag-icon", width: "20", height: "20" %>
         <span>不適切な商品の通報</span>
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
@@ -90,22 +85,18 @@
         不快な言葉遣いなどは利用制限や退会処分となることがあります。
       </p>
       <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
+        <%= image_tag "comment.png", class: "comment-flag-icon", width: "20", height: "25" %>
+        <span>コメントする</span>
       </button>
     </form>
   </div>
+
   <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
+    <a href="#" class="change-item-btn">＜ 前の商品</a>
+    <a href="#" class="change-item-btn">後ろの商品 ＞</a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 
   root to: 'items#index'
 


### PR DESCRIPTION
## What  
商品詳細表示機能を実装  
- 商品一覧から詳細ページへ遷移できるように  
- 商品情報の表示  
- ユーザーや販売状況に応じたボタンの出し分け  

## Why  
購入前に商品情報を確認できるようにするため  
適切なユーザーにのみ操作ボタンが表示されるようにするため  

---

## 動作確認動画

- ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/8223fbb8f4fd05468466eba00cd61c28

- ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画 
https://gyazo.com/5e1228cf919adc22d503ac9f9b21415c

- ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/4d6f5f11712260424a1cd0e03c4b7371
