### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit]
   before_action :set_select_data, only: [:new, :edit, :update]
-  before_action :set_item, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def edit
     redirect_to root_path unless current_user == @item.user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -68,3 +68,5 @@ class ItemsController < ApplicationController
     ).merge(user_id: current_user.id)
   end
 end
+
+# 商品情報編集機能の微修正

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,23 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_select_data, only: [:new, :edit, :update]
+  before_action :set_item, only: [:edit, :update]
+
+  def edit
+    redirect_to root_path unless current_user == @item.user
+  end
+
+  def update
+    if current_user == @item.user
+      if @item.update(item_params)
+        redirect_to item_path(@item), notice: '商品を更新しました'
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    else
+      redirect_to root_path
+    end
+  end
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -23,6 +41,18 @@ class ItemsController < ApplicationController
   end
 
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def set_select_data
+    @categories = Category.all
+    @conditions = Condition.all
+    @shipping_fee_statuses = ShippingFeeStatus.all
+    @prefectures = Prefecture.all
+    @scheduled_deliveries = ScheduledDelivery.all
+  end
 
   def item_params
     params.require(:item).permit(

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,17 +1,8 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
-<div class="items-sell-contents">
-  <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-  </header>
-  <div class="items-sell-main">
-    <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, local: true, html: { multipart: true } do |f| %>
+<%= form_with model: item, local: true, html: { multipart: true } do |f| %>
 
 
     <%= render 'shared/error_messages', model: f.object %>
-    
+
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -23,6 +14,7 @@ app/assets/stylesheets/items/new.css %>
           クリックしてファイルをアップロード
         </p>
         <%= f.file_field :image, id:"item-image" %>
+
       </div>
     </div>
     <%# /商品画像 %>
@@ -56,7 +48,7 @@ app/assets/stylesheets/items/new.css %>
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:condition_id, @conditions, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, @conditions, :id, :name, {}, {class: "select-box", id: "item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -72,17 +64,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_fee_status_id, @shipping_fee_statuses, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_status_id, @shipping_fee_statuses, :id, :name, {}, {class: "select-box", id: "item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_id, @prefectures, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, @prefectures, :id, :name, {}, {class: "select-box", id: "item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:scheduled_delivery_id, @scheduled_deliveries, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, @scheduled_deliveries, :id, :name, {}, {class: "select-box", id: "item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -100,7 +92,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class: "price-input", id: "item-price", placeholder: "例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -139,22 +131,9 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "出品する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>
-  <% end %>
-
-  <footer class="items-sell-footer">
-    <ul class="menu">
-      <li><a href="#">プライバシーポリシー</a></li>
-      <li><a href="#">フリマ利用規約</a></li>
-      <li><a href="#">特定商取引に関する表記</a></li>
-    </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-    <p class="inc">
-      ©︎Furima,Inc.
-    </p>
-  </footer>
-</div>
+<% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -140,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
  
     <% if user_signed_in? %>
      <% if current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
      <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 
   root to: 'items#index'
 


### PR DESCRIPTION
What
商品情報編集機能を実装しました。
※作業ブランチを作成する前にmainで実装してしまったため、差分を作るために軽微な修正を加えています。

Why
出品した商品の内容を出品者自身が編集できるようにするため。

動作確認用Gyazo
ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/543b0145d82d606a274bcba604cbbe77

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/23a454c48477a1a5f5b2dd3ae448d178

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/056c3ee3d867800b4c3519c5e317ea07

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/7bda029fc55bcba169379f41e05de677

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/2403dd58fbc2a077f68d6b5286bf645b

ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）→未実装

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/e3542df560c30bdb0d3d457ac921f426

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/76f952239eef982b9f8b82b490936659
