### PR TITLE
商品購入機能 first commit (2025/8/5)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,4 +83,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'pry-rails'
 end
+
+gem 'payjp'

--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,5 @@ group :development, :test do
 end
 
 gem 'payjp'
+
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -114,6 +115,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
+    domain_name (0.6.20240107)
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
@@ -126,6 +128,9 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http-accept (1.7.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -153,6 +158,11 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
+    method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0729)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -167,6 +177,7 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
@@ -177,11 +188,19 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    payjp (1.1.7)
+      base64
+      rest-client (~> 2.0)
     pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
     prism (1.4.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.2.6)
       date
       stringio
@@ -237,6 +256,11 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.4.1)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
@@ -329,7 +353,9 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)
+  payjp
   pg
+  pry-rails
   puma (>= 5.0)
   rails (~> 7.1.0)
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,11 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
@@ -166,6 +171,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_json (1.17.0)
     mutex_m (0.3.0)
     mysql2 (0.5.6)
     net-imap (0.5.9)
@@ -253,6 +259,8 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -350,6 +358,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gon
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### Association
 - has_many :items
-- has_many :purchases
+- has_many :orders
 
 
 ## items テーブル
@@ -33,10 +33,10 @@
 
 ### Association
 - belongs_to :user
-- has_one :purchase
+- has_one :order
 
 
-## purchases テーブル
+## orders テーブル
 
 | Column | Type       | Options                         |
 | ------ | ---------- | ------------------------------- |
@@ -59,7 +59,7 @@
 | address_line  | string     | null: false                     |
 | building       | string     |                                 |
 | phone_number  | string     | null: false                     |
-| purchase       | references | null: false, foreign\_key: true |
+| order       | references | null: false, foreign\_key: true |
 
 ### Association
-- belongs_to :purchase
+- belongs_to :order

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -205,3 +205,17 @@
   font-weight: bold;
   font-size: 23px;
 }
+
+.sold-out-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 10px 20px;
+  font-size: 30px;
+  font-weight: bold;
+  border-radius: 8px;
+  z-index: 10;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_select_data, only: [:new, :edit, :update]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :redirect_unless_owner, only: [:edit, :update, :destroy]
+  before_action :redirect_if_sold_out, only: [:edit, :update]
 
   def edit
   end
@@ -46,6 +47,10 @@ class ItemsController < ApplicationController
     redirect_to root_path unless current_user == @item.user
   end
 
+  def redirect_if_sold_out
+    redirect_to root_path if @item.order.present?
+  end
+
   def set_item
     @item = Item.find(params[:id])
   end
@@ -72,5 +77,3 @@ class ItemsController < ApplicationController
     ).merge(user_id: current_user.id)
   end
 end
-
-# 商品情報編集機能の微修正

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,6 +5,7 @@ class OrdersController < ApplicationController
 
   def index
     @order_address = OrderAddress.new
+    gon.public_key = ENV['PAYJP_PUBLIC_KEY']
   end
 
   def create

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,48 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_item
+  before_action :redirect_if_invalid_access
+
+  def index
+    @order_address = OrderAddress.new
+  end
+
+  def create
+    @order_address = OrderAddress.new(order_params)
+    if @order_address.valid?
+      pay_item
+      @order_address.save
+      redirect_to root_path
+    else
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def order_params
+    params.require(:order_address).permit(
+      :postal_code, :prefecture_id, :city, :house_number,
+      :building_name, :phone_number
+    ).merge(user_id: current_user.id, item_id: @item.id, token: params[:token])
+  end
+
+  def set_item
+    @item = Item.find(params[:item_id])
+  end
+
+  def redirect_if_invalid_access
+    return unless current_user.id == @item.user_id || @item.order.present?
+
+    redirect_to root_path
+  end
+
+  def pay_item
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp::Charge.create(
+      amount: @item.price,
+      card: order_params[:token],
+      currency: 'jpy'
+    )
+  end
+end

--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -1,0 +1,2 @@
+module DonationsHelper
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,4 @@ import "@hotwired/turbo-rails"
 import "controllers"
 
 import "item_price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,5 +1,5 @@
 const pay = () => {
-  const payjp = Payjp('pk_test_ad3c44dc66fef70952944a0a'); 
+  const payjp = Payjp(gon.public_key);
   const elements = payjp.elements();
 
   const numberElement = elements.create('cardNumber');
@@ -36,3 +36,4 @@ const pay = () => {
 };
 
 window.addEventListener("turbo:load", pay);
+window.addEventListener("turbo:render", pay);

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,38 @@
+const pay = () => {
+  const payjp = Payjp('pk_test_ad3c44dc66fef70952944a0a'); 
+  const elements = payjp.elements();
+
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
+  const form = document.getElementById('charge-form');
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+
+    payjp.createToken(numberElement).then((response) => {
+      if (response.error) {
+        alert("カード情報に誤りがあります");
+      } else {
+        const token = response.id;
+        const tokenObj = document.createElement("input");
+        tokenObj.setAttribute("type", "hidden");
+        tokenObj.setAttribute("name", "token");
+        tokenObj.setAttribute("value", token);
+        form.appendChild(tokenObj);
+
+        numberElement.clear();
+        expiryElement.clear();
+        cvcElement.clear();
+
+        form.submit();
+      }
+    });
+  });
+};
+
+window.addEventListener("turbo:load", pay);

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -16,7 +16,7 @@ const pay = () => {
 
     payjp.createToken(numberElement).then((response) => {
       if (response.error) {
-        alert("カード情報に誤りがあります");
+        return;
       } else {
         const token = response.id;
         const tokenObj = document.createElement("input");

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
+  has_one :order
 
   # ActiveStorageで画像を持たせる
   has_one_attached :image

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,4 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,5 @@
 class Order < ApplicationRecord
   belongs_to :user
   belongs_to :item
+  has_one :order_address
 end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,30 @@
+class OrderAddress
+  include ActiveModel::Model
+
+  attr_accessor :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number,
+                :user_id, :item_id, :token
+
+  with_options presence: true do
+    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+    validates :city
+    validates :house_number
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'is invalid' }
+    validates :user_id
+    validates :item_id
+    validates :token
+  end
+
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Address.create(
+      postal_code: postal_code,
+      prefecture_id: prefecture_id,
+      city: city,
+      house_number: house_number,
+      building_name: building_name,
+      phone_number: phone_number,
+      order_id: order.id
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,6 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/, message: 'は全角カタカナで入力してください' }
   validates :birth_date, presence: true
   validates :password, format: { with: /\A(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]+\z/, message: 'は英字と数字の両方を含めてください' }
+
+  has_many :orders
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,5 @@ class User < ApplicationRecord
   validates :password, format: { with: /\A(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]+\z/, message: 'は英字と数字の両方を含めてください' }
 
   has_many :orders
+  has_many :items
 end

--- a/app/views/donations/new.html.erb
+++ b/app/views/donations/new.html.erb
@@ -1,0 +1,151 @@
+<%= render "shared/second-header"%>
+
+<div style="display: flex; justify-content: center;">
+  <div class='transaction-contents'>
+    <div class='transaction-main'>
+      <h1 class='transaction-title-text'>
+        購入内容の確認
+      </h1>
+
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= "商品名" %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= '999,999,999' %></p>
+          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= "販売価格" %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with model: @order_address, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap', local: true, data: { turbo: false } do |f| %>
+
+
+     <% if @order_address.errors.any? %>
+ <div id="error_explanation" style="text-align: center; margin-bottom: 20px;">
+    <ul style="display: inline-block; text-align: left; color: red; list-style: none; padding-left: 0;">
+      <% @order_address.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+
+ <%# カード情報の入力 %>
+<div class='credit-card-form'>
+  <h1 class='info-input-haedline'>
+    クレジットカード情報入力
+  </h1>
+
+  <!-- ⭐️ カード番号 -->
+  <div class="form-group">
+    <div class='form-text-wrap'>
+      <label class="form-text">カード番号</label>
+      <span class="indispensable">必須</span>
+    </div>
+    <div id="number-form" class="input-default"></div>
+
+  </div>
+
+  <!-- ⭐️ 有効期限 -->
+<div class="form-group">
+  <div class='form-text-wrap'>
+    <label class="form-text">有効期限</label>
+    <span class="indispensable">必須</span>
+  </div>
+  <div id="expiry-form" class="input-default"></div>
+</div>
+
+  <!-- ⭐️ CVC -->
+  <div class="form-group">
+    <div class='form-text-wrap'>
+      <label class="form-text">セキュリティコード</label>
+      <span class="indispensable">必須</span>
+    </div>
+    <div id="cvc-form" class="input-default"></div>
+
+  </div>
+    <%# /カード情報の入力 %>
+    
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
+
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区" %>
+
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :house_number, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1" %>
+
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :building_name, class:"input-default", id:"building", placeholder:"例）柳ビル103" %>
+
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678", maxlength:"11" %>
+
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+
+    </div> <!-- /.transaction-main -->
+  </div>   <!-- /.transaction-contents -->
+</div>     <!-- /中央寄せの外枠 -->
+<%= render "shared/second-footer"%>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -148,30 +148,29 @@
   </li>
 <% else %>
   <!-- 商品がある場合の一覧表示 -->
-  <% @items.each do |item| %>
-    <li class='list'>
-      <%= link_to item_path(item) do %>
-        <div class='item-img-content'>
-          <% if item.order.present? %>
-    <div class="sold-out-overlay">sold out</div>
-  <% end %>
-          <%= image_tag item.image, class: "item-img" %>
-          <%# 商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'><%= item.name %></h3>
-          <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
+<% @items.each do |item| %>
+  <li class='list'>
+    <%= link_to item_path(item) do %>
+      <div class='item-img-content'>
+        <% if item.order.present? %>
+          <div class="sold-out"><span>Sold Out!!</span></div>
+        <% end %>
+        <%= image_tag item.image, class: "item-img" %>
+      </div>
+      <div class='item-info'>
+        <h3 class='item-name'><%= item.name %></h3>
+        <div class='item-price'>
+          <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span>
+          <div class='star-btn'>
+            <%= image_tag "star.png", class:"star-icon" %>
+            <span class='star-count'>0</span>
           </div>
         </div>
-      <% end %>
-    </li>
-  <% end %>
+      </div>
+    <% end %>
+  </li>
+<% end %>
+
 <% end %>
 </ul>
           

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -152,6 +152,9 @@
     <li class='list'>
       <%= link_to item_path(item) do %>
         <div class='item-img-content'>
+          <% if item.order.present? %>
+    <div class="sold-out-overlay">sold out</div>
+  <% end %>
           <%= image_tag item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,7 +10,7 @@
   <% if @item.image.attached? %>
     <div class="item-image-wrapper" style="position: relative;">
       <% if @item.order.present? %>
-        <div class="sold-out-overlay">sold out</div>
+        <div class="sold-out"><span>sold out</span></div>
       <% end %>
       <%= image_tag @item.image, class: "item-box-img" %>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,12 +7,15 @@
     </h2>
 
     <div class="item-img-content">
-      <% if @item.image.attached? %>
-        <div class="item-image-wrapper">
-          <%= image_tag @item.image, class: "item-box-img" %>
-        </div>
+  <% if @item.image.attached? %>
+    <div class="item-image-wrapper" style="position: relative;">
+      <% if @item.order.present? %>
+        <div class="sold-out-overlay">sold out</div>
       <% end %>
+      <%= image_tag @item.image, class: "item-box-img" %>
     </div>
+  <% end %>
+</div>
 
     <div class="item-price-box">
       <span class="item-price">
@@ -24,13 +27,15 @@
     </div>
  
     <% if user_signed_in? %>
-     <% if current_user.id == @item.user_id %>
+     <% if current_user.id == @item.user_id && @item.order.nil? %>
       <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
      <% else %>
-      <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
-     <% end %> 
+  <% unless @item.order.present? %>
+    <%= link_to "購入画面に進む", item_orders_path(@item), data: { turbo: false }, class: "item-red-btn" %>
+  <% end %>
+<% end %>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script src="https://js.pay.jp/v2/pay.js"></script>
+
     <title>Furima42057</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
@@ -12,5 +14,10 @@
 
   <body>
     <%= yield %>
+
+    <!-- ✅ JSファイルはbodyの一番最後に読み込むのが確実 -->
+  <% if controller.controller_name == 'orders' && controller.action_name == 'index' %>
+    <%= javascript_include_tag 'card', type: 'module', 'data-turbo-track': 'reload' %>
+  <% end %>
   </body>
 </html>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -32,9 +32,9 @@
     <%# /支払額の表示 %>
 
     <% if @order_address.errors.any? %>
-  <div class="error-messages">
+  <div class="error-messages" style="text-align: center; color: red; margin-bottom: 20px;">
     <% @order_address.errors.full_messages.each do |message| %>
-      <p style="color: red;"><%= message %></p>
+      <p><%= message %></p>
     <% end %>
   </div>
 <% end %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -31,13 +31,8 @@
     </div>
     <%# /支払額の表示 %>
 
-    <% if @order_address.errors.any? %>
-  <div class="error-messages" style="text-align: center; color: red; margin-bottom: 20px;">
-    <% @order_address.errors.full_messages.each do |message| %>
-      <p><%= message %></p>
-    <% end %>
-  </div>
-<% end %>
+    <%= render 'shared/error_messages', object: @order_address %>
+ 
 
 
     <%= form_with model: @order_address, id: 'charge-form', class: 'transaction-form-wrap', url: item_orders_path(@item), local: true do |f| %>
@@ -136,5 +131,7 @@
   </div>
 </div>
 <%= render "shared/second-footer"%>
+
+<%= include_gon %>
 
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image, class: 'buy-item-img' if @item.image.attached? %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= number_with_delimiter(@item.price) %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_fee_status.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,22 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= number_with_delimiter(@item.price) %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <% if @order_address.errors.any? %>
+  <div class="error-messages">
+    <% @order_address.errors.full_messages.each do |message| %>
+      <p style="color: red;"><%= message %></p>
+    <% end %>
+  </div>
+<% end %>
+
+
+    <%= form_with model: @order_address, id: 'charge-form', class: 'transaction-form-wrap', url: item_orders_path(@item), local: true do |f| %>
+
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -79,42 +89,43 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :house_number, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building_name, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>
@@ -125,3 +136,5 @@
   </div>
 </div>
 <%= render "shared/second-footer"%>
+
+

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
-<% if model.errors.any? %>
+<% if object.errors.any? %>
 <div class="error-alert">
   <ul>
-    <% model.errors.full_messages.each do |message| %>
+    <% object.errors.full_messages.each do |message| %>
     <li class='error-message'><%= message %></li>
     <% end %>
   </ul>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,4 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 
 pin "item_price", to: "item_price.js"
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 
   root to: 'items#index'
 
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
+    resources :orders, only: [:index, :create]
+  end
 end

--- a/db/migrate/20250801223635_create_orders.rb
+++ b/db/migrate/20250801223635_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250801230602_create_addresses.rb
+++ b/db/migrate/20250801230602_create_addresses.rb
@@ -1,0 +1,15 @@
+class CreateAddresses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :addresses do |t|
+      t.string :postal_code
+      t.integer :prefecture_id
+      t.string :city
+      t.string :house_number
+      t.string :building_name
+      t.string :phone_number
+      t.references :order, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_17_231138) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_01_230602) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,19 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_17_231138) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "addresses", charset: "utf8mb3", force: :cascade do |t|
+    t.string "postal_code"
+    t.integer "prefecture_id"
+    t.string "city"
+    t.string "house_number"
+    t.string "building_name"
+    t.string "phone_number"
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
   create_table "items", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
@@ -52,6 +65,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_17_231138) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", charset: "utf8mb3", force: :cascade do |t|
@@ -74,5 +96,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_17_231138) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :address do
+    postal_code { "MyString" }
+    prefecture_id { 1 }
+    city { "MyString" }
+    house_number { "MyString" }
+    building_name { "MyString" }
+    phone_number { "MyString" }
+    order { nil }
+  end
+end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :address do
-    postal_code { "MyString" }
+    postal_code { 'MyString' }
     prefecture_id { 1 }
-    city { "MyString" }
-    house_number { "MyString" }
-    building_name { "MyString" }
-    phone_number { "MyString" }
+    city { 'MyString' }
+    house_number { 'MyString' }
+    building_name { 'MyString' }
+    phone_number { 'MyString' }
     order { nil }
   end
 end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :order_address do
+    postal_code    { '123-4567' }
+    prefecture_id  { 2 }
+    city           { '横浜市' }
+    house_number   { '青山1-1-1' }
+    building_name  { '柳ビル103' }
+    phone_number   { '09012345678' }
+    token          { 'tok_abcdefghijk00000000000000000' }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :order do
+    user { nil }
+    item { nil }
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  before do
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item)
+    @order_address = FactoryBot.build(:order_address, user_id: user.id, item_id: item.id)
+    sleep(0.1) # 画像の処理などで一時停止が必要な場合
+  end
+
+  describe '商品購入' do
+    context '購入できる場合' do
+      it 'すべての情報が正しく入力されていれば購入できる' do
+        expect(@order_address).to be_valid
+      end
+
+      it '建物名が空でも購入できる' do
+        @order_address.building_name = ''
+        expect(@order_address).to be_valid
+      end
+    end
+
+    context '購入できない場合' do
+      it '郵便番号が空では購入できない' do
+        @order_address.postal_code = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Postal code can't be blank")
+      end
+
+      it '郵便番号にハイフンがないと購入できない' do
+        @order_address.postal_code = '1234567'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
+      end
+
+      it '都道府県が1だと購入できない' do
+        @order_address.prefecture_id = 1
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it '市区町村が空では購入できない' do
+        @order_address.city = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("City can't be blank")
+      end
+
+      it '番地が空では購入できない' do
+        @order_address.house_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("House number can't be blank")
+      end
+
+      it '電話番号が空では購入できない' do
+        @order_address.phone_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number can't be blank")
+      end
+
+      it '電話番号が9桁以下では購入できない' do
+        @order_address.phone_number = '123456789'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Phone number is invalid')
+      end
+
+      it '電話番号が12桁以上では購入できない' do
+        @order_address.phone_number = '123456789012'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Phone number is invalid')
+      end
+
+      it '電話番号にハイフンが含まれていると購入できない' do
+        @order_address.phone_number = '090-1234-5678'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Phone number is invalid')
+      end
+
+      it 'tokenが空では購入できない' do
+        @order_address.token = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      end
+
+      it 'user_idが空では購入できない' do
+        @order_address.user_id = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("User can't be blank")
+      end
+
+      it 'item_idが空では購入できない' do
+        @order_address.item_id = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Item can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/donations_spec.rb
+++ b/spec/requests/donations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Donations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/donations_spec.rb
+++ b/spec/requests/donations_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Donations", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Donations', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Orders", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Orders', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
What
商品購入機能を実装しました。

Why
ユーザーが商品をクレジットカードで購入できるようにするため。

動作確認用動画・画像
・必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/a876cb36784fef1656b2696562016fce

・入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/e8ef543987517c8ba3b72dfd9a37903f
https://gyazo.com/930ea7e17489f48d49c6f9ff36e5a3dd

・ログイン状態でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/ad63bcd32f35ea5ba9f3686ccdbf9375

・ログイン状態でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/88e42b72ca0494fbb8c7e13ad645fee6

・ログアウト状態では、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/1c7de1a40c622299cdd9fbe68c678df5

・売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/8c1e70cb697ecb5500d1dcd50a4b6cd9

・売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/8c1e70cb697ecb5500d1dcd50a4b6cd9

・ログイン状態でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/d40c20fad851391422fc6a679f403b9c

・ログイン状態でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/8583b77266c0483fc9f85bc29c9be717

・テスト結果の画像（RSpec実行結果）
https://gyazo.com/0b768f12396e2ae058e54b4355effb51
https://gyazo.com/565709cf46a17092030f0fcfd2121262

